### PR TITLE
Remove Space On Author Name

### DIFF
--- a/templates/Outer-Wilds-Mod-Template/$safeprojectname$.csproj
+++ b/templates/Outer-Wilds-Mod-Template/$safeprojectname$.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Copyright>Copyright © $year$ $username$</Copyright>
+    <Copyright>Copyright © $year$ $unsafe_username$</Copyright>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/templates/Outer-Wilds-Mod-Template/.template.config/template.json
+++ b/templates/Outer-Wilds-Mod-Template/.template.config/template.json
@@ -62,8 +62,14 @@
       "displayName": "Author Name",
       "defaultValue": "Ernesto",
       "datatype": "string",
-      "replaces": "$username$",
+      "replaces": "$unsafe_username$",
       "description": "Author of this mod (no spaces!)"
+    },
+    "SafeAuthorName": {
+      "type": "derived",
+      "valueSource": "AuthorName",
+      "valueTransform": "RemoveSpaces",
+      "replaces": "$username$"
     },
     "year": {
       "type": "generated",
@@ -102,6 +108,13 @@
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
     }
+  },
+  "forms": {
+      "RemoveSpaces": {
+        "identifier": "replace",
+	"pattern": "(\\s)",
+	"replacement": ""
+      }
   },
   "postActions": [
     {

--- a/templates/Outer-Wilds-Mod-Template/manifest.json
+++ b/templates/Outer-Wilds-Mod-Template/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ow-mods/owml/master/schemas/manifest_schema.json",
   "filename": "$safeprojectname$.dll",
-  "author": "$username$",
+  "author": "$unsafe_username$",
   "name": "$safeprojectname$",
   "uniqueName": "$username$.$safeprojectname$",
   "version": "0.1.0",

--- a/templates/Outer-Wilds-Mod-Template/parent-stuff/LICENSE
+++ b/templates/Outer-Wilds-Mod-Template/parent-stuff/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) $year$ $username$
+Copyright (c) $year$ $unsafe_username$
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Removes spaces in the author name if it has them, `$unsafe_username$` will preserve the spaces for stuff like LICENSE, copyright, etc.
